### PR TITLE
Add Homebrew Formula for Melodica

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Melodica is a console-based audio player built with Go. It supports playback of 
 
 ## Screenshot
 
-<img width="1505" alt="image" src="https://github.com/user-attachments/assets/d6e6e43b-73ad-4cab-a998-d6e8855a3f4a">
+<img width="1829" alt="image" src="https://github.com/user-attachments/assets/77c12fa6-4d3b-4f5b-8617-bdb1b9e0a7e2">
 
 ## Features
 
@@ -25,7 +25,24 @@ Melodica is a console-based audio player built with Go. It supports playback of 
 
 ## Installation
 
-To install Melodica, ensure you have Go installed (version 1.20 or later). You can install the latest version of Melodica directly from the GitHub repository using the following command:
+### Homebrew (macOS)
+
+To install Melodica on macOS via Homebrew, use the following commands:
+
+1. Tap the repository:
+
+   ```bash
+   brew tap zombocoder/melodica
+   ```
+
+2. Install Melodica:
+   ```bash
+   brew install melodica
+   ```
+
+### Go Installation
+
+If you prefer to install Melodica via Go, ensure you have Go installed (version 1.20 or later), then run:
 
 ```bash
 go install github.com/zombocoder/melodica/cmd/melodica@latest

--- a/melodica.rb
+++ b/melodica.rb
@@ -2,7 +2,7 @@ class Melodica < Formula
     desc "Melodica is a console-based audio player built with Go"
     homepage "https://github.com/zombocoder/melodica"
     url "https://github.com/zombocoder/melodica/archive/v0.0.2.tar.gz"
-    sha256 "6f66853918049596774ccfa098109aa57d8b852bbfddfc88e5773346375cdb8c" # Replace with the SHA256 hash of the tarball
+    sha256 "6f66853918049596774ccfa098109aa57d8b852bbfddfc88e5773346375cdb8c"
     license "MIT"
     version "0.0.2"
   

--- a/melodica.rb
+++ b/melodica.rb
@@ -1,0 +1,19 @@
+class Melodica < Formula
+    desc "Melodica is a console-based audio player built with Go"
+    homepage "https://github.com/zombocoder/melodica"
+    url "https://github.com/zombocoder/melodica/archive/v0.0.2.tar.gz"
+    sha256 "6f66853918049596774ccfa098109aa57d8b852bbfddfc88e5773346375cdb8c" # Replace with the SHA256 hash of the tarball
+    license "MIT"
+    version "0.0.2"
+  
+    depends_on "go" => :build
+  
+    def install
+      system "go", "build", *std_go_args(output: bin/"melodica"), "./cmd/melodica"
+    end
+  
+    test do
+      assert_match "Usage: melodica <playlist.txt>", shell_output("#{bin}/melodica -h", 2)
+    end
+  end
+  


### PR DESCRIPTION
#### Summary
This PR introduces a Homebrew formula to make it easier to install and manage the `melodica` console-based audio player on macOS systems via Homebrew.

#### Changes
- Added a `melodica.rb` formula file to the `homebrew-melodica` tap repository.
- The formula specifies installation instructions for `melodica`, including:
  - **Download URL** for the latest release tarball.
  - **SHA256 checksum** to verify the integrity of the downloaded file.
  - **Go build instructions** to compile the `melodica` binary.
  - **Dependencies** that ensure Go is installed for building.
  - A **test block** to validate successful installation.

#### How to Use
1. Tap the new Homebrew repository:
   ```bash
   brew tap zombocoder/melodica
   ```

2. Install `melodica`:
   ```bash
   brew install melodica
   ```

#### Additional Information
This formula will allow users to easily install, manage, and update `melodica` through Homebrew, enhancing accessibility for macOS users. Future updates to `melodica` can be distributed through this formula by updating the URL, SHA256 checksum, and version number in the formula file.

#### Testing
This PR includes a basic test to verify that the `melodica` binary installs correctly and outputs the expected usage information. 